### PR TITLE
Top level union, Type alias, better Union selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Supported Options:
   - `key`: the `type` (or `logicalType`)
   - `value`: should be a generator function `(type, context) => value` where - `type`: the content of the `type` field in the schema, either a `string` for simple type, or the type configuration for complex types - `context`: an object with contextual data, including the `generators`
     It is possible to override the default generators, and add support for extra types/logicalTypes by providing
+- `pickUnion`: Array of strings to drive which member of union type to choose. Can be the short name of fully namespaced names. When this option is not provided, the first element in the union will be chosen
 
 ## Supported Avro features
 
@@ -39,11 +40,10 @@ Based on the Avro 1.9.0 [specification](https://avro.apache.org/docs/current/spe
 - All logical types
   - including custom logicalTypes using the `options` parameter. If a `logicalType` is missing a generator, data will be generated matching the underlying `type`.
 - All complex types
-  - Note that for `enum` and `union` types, the first element of the array will always be chosen. This allows the caller to drive the behaviour of the generator to return the expected type
+  - Note that for `enum` types, the first element of the array will always be chosen.
+- Type Alias
 
 **Partial support for namespaces**. Only union types are namespaced, unconditionally.
-
-**Aliases** are not currently supported.
 
 ## Contributing
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,11 +105,9 @@ function generateRecord(avroSchema, context) {
   const { fields, namespace } = avroSchema;
 
   return fields.reduce((record, { name, type }) => {
-    if (Array.isArray(type)) {
-      record[name] = generateUnionType(type, namespace, context);
-    } else {
-      record[name] = generateDataForType(type, context);
-    }
+    record[name] = Array.isArray(type)
+      ? generateUnionType(type, namespace, context)
+      : generateDataForType(type, context);
 
     return record;
   }, {});

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -258,5 +258,52 @@ describe('Avro mock data generator', () => {
     expect(result).toEqual({ chickenName: 'henry' });
   });
 
-  // TODO test references to previous schemas
+  it('supports type alias', () => {
+    const result = generateData({
+      type: 'record',
+      fields: [
+        {
+          name: 'Rooster',
+          type: 'chicken',
+        },
+        {
+          name: 'hen',
+          type: {
+            type: 'record',
+            name: 'chicken',
+            fields: [{ name: 'chickenName', type: 'string' }],
+          },
+        },
+      ],
+    });
+    expect(result).toEqual({
+      Rooster: { chickenName: expect.any(String) },
+      hen: { chickenName: expect.any(String) },
+    });
+  });
+
+  it('supports fully qualified type alias', () => {
+    const result = generateData({
+      type: 'record',
+      fields: [
+        {
+          name: 'Rooster',
+          type: 'space.chicken',
+        },
+        {
+          name: 'hen',
+          type: {
+            type: 'record',
+            name: 'chicken',
+            namespace: 'space',
+            fields: [{ name: 'chickenName', type: 'string' }],
+          },
+        },
+      ],
+    });
+    expect(result).toEqual({
+      Rooster: { chickenName: expect.any(String) },
+      hen: { chickenName: expect.any(String) },
+    });
+  });
 });

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -174,6 +174,36 @@ describe('Avro mock data generator', () => {
     });
   });
 
+  it('supports top level union types', () => {
+    const result = generateData([
+      {
+        type: 'record',
+        name: 'Owners',
+        namespace: 'com.farms',
+        fields: [
+          {
+            name: 'name',
+            type: 'string',
+          },
+        ],
+      },
+      {
+        type: 'record2',
+        namespace: 'com.farms',
+        name: 'Animals',
+        fields: [
+          {
+            name: 'breed',
+            type: 'string',
+          },
+        ],
+      },
+    ]);
+    expect(result).toEqual({
+      'com.farms.Owners': { name: expect.any(String) },
+    });
+  });
+
   it('supports enum types', () => {
     const result = generateData({
       type: 'record',
@@ -227,4 +257,6 @@ describe('Avro mock data generator', () => {
     );
     expect(result).toEqual({ chickenName: 'henry' });
   });
+
+  // TODO test references to previous schemas
 });

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -249,7 +249,7 @@ describe('Avro mock data generator', () => {
         ],
       },
       {
-        type: 'record2',
+        type: 'record',
         namespace: 'com.farms',
         name: 'Animals',
         fields: [

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -174,6 +174,67 @@ describe('Avro mock data generator', () => {
     });
   });
 
+  it('lets the caller pick union by short name', () => {
+    // 1/1000 chances that this test falsely pass is deemed acceptable, but you can always up the number
+    const unionType = Array(1000).fill({
+      type: 'record',
+      name: 'CityFarm',
+      fields: [{ name: 'nbPidgeons', type: 'int' }],
+    });
+    unionType[550] = {
+      type: 'record',
+      name: 'CountryFarm',
+      fields: [{ name: 'nbChickens', type: 'int' }],
+    };
+
+    const result = generateData(
+      {
+        type: 'record',
+        fields: [
+          {
+            name: 'farm',
+            type: unionType,
+          },
+        ],
+      },
+      { pickUnion: ['CountryFarm'] },
+    );
+    expect(result).toEqual({
+      farm: { CountryFarm: { nbChickens: expect.any(Number) } },
+    });
+  });
+
+  it('lets the caller pick union by full name', () => {
+    // 1/1000 chances that this test falsely pass is deemed acceptable, but you can always up the number
+    const unionType = Array(1000).fill({
+      type: 'record',
+      name: 'CityFarm',
+      fields: [{ name: 'nbPidgeons', type: 'int' }],
+    });
+    unionType[550] = {
+      type: 'record',
+      name: 'CountryFarm',
+      fields: [{ name: 'nbChickens', type: 'int' }],
+    };
+
+    const result = generateData(
+      {
+        type: 'record',
+        namespace: 'my.lovely',
+        fields: [
+          {
+            name: 'farm',
+            type: unionType,
+          },
+        ],
+      },
+      { pickUnion: ['my.lovely.CountryFarm'] },
+    );
+    expect(result).toEqual({
+      farm: { 'my.lovely.CountryFarm': { nbChickens: expect.any(Number) } },
+    });
+  });
+
   it('supports top level union types', () => {
     const result = generateData([
       {


### PR DESCRIPTION
I plan to release this as a minor version, as I don't think it will be breaking anything.

### Draft release notes
- Add support for Top Level Union types
- Add support for type aliases (short and fully qualified name)
- Add `pickUnion` option so you can choose which member of any union type should be generated. Works with both short and fully qualified name.