### PR TITLE
Update `uuid`

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
   },
   "dependencies": {
     "mersenne-twister": "^1.1.0",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3725,10 +3725,10 @@ uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
-uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://na.artifactory.swg-devops.com/artifactory/api/npm/appconnect-npm/uuid/-/uuid-9.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fuuid%2F-%2Fuuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
 validate-npm-package-license@^3.0.1:
   version "3.0.4"


### PR DESCRIPTION
We are having some trouble with Jest testing downstream because `@ovotech/avro-mock-generator` is still using `uuid@8.3.2`, which lacks [this fix](https://github.com/uuidjs/uuid/pull/616). This PR upgrades you to `uuid@9`, which has the fix.